### PR TITLE
Use jupyterlab instead of jupyter in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - scikit-image
-  - jupyter
+  - jupyterlab
   - tifffile
   - imagecodecs
   - napari


### PR DESCRIPTION
The `README` says to make sure that you can launch a jupyter (lab) notebook using the `jupyter lab` command. The `environment.yml` does not include `jupyterlab`, which is required for this to happen (unless relying on jupyter lab in the base environment). 

Looking forward to the tutorial!

```bash
~/demos/napari-training-course master
(base) ❯ conda env create -f environment.yml
(base) ❯ conda activate napari
(napari) ❯ jupyter lab                                                     
Traceback (most recent call last):
  File "/Users/trevormanz/dev/miniconda3/envs/napari/bin/jupyter", line 11, in <module>
    sys.exit(main())
  File "/Users/trevormanz/dev/miniconda3/envs/napari/lib/python3.7/site-packages/jupyter_core/command.py", line 247, in main
    command = _jupyter_abspath(subcommand)
  File "/Users/trevormanz/dev/miniconda3/envs/napari/lib/python3.7/site-packages/jupyter_core/command.py", line 134, in _jupyter_abspath
    'Jupyter command `{}` not found.'.format(jupyter_subcommand)
Exception: Jupyter command `jupyter-lab` not found.
```
